### PR TITLE
Add std module examples

### DIFF
--- a/std/README.md
+++ b/std/README.md
@@ -1,0 +1,14 @@
+# Zig Standard Library Examples
+
+This directory contains small examples for modules from Zig's `std` library.
+Each subfolder focuses on a single module and includes:
+
+- a `main.zig` demonstrating basic usage
+- a `README.md` with a short tutorial
+
+Available modules:
+- [`std.fs`](fs/) – filesystem operations
+- [`std.fmt`](fmt/) – formatting utilities
+- [`std.io`](io/) – input/output helpers
+
+Run an example with `zig run <module>/main.zig`.

--- a/std/fmt/README.md
+++ b/std/fmt/README.md
@@ -1,0 +1,11 @@
+# std.fmt – formatting tutorial
+
+Demonstrates string formatting into a buffer using `std.fmt`.
+
+```sh
+zig run main.zig
+```
+
+## Key functions
+- `std.fmt.bufPrint` – format into an existing buffer
+- `std.debug.print` – write formatted text to stdout

--- a/std/fmt/main.zig
+++ b/std/fmt/main.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var buffer: [64]u8 = undefined;
+    const text = try std.fmt.bufPrint(&buffer, "Witaj {s}, liczba {d}\n", .{"Zig", 42});
+    std.debug.print("{s}", .{text});
+}

--- a/std/fs/README.md
+++ b/std/fs/README.md
@@ -1,0 +1,104 @@
+# std.fs – filesystem reference
+
+This directory contains an executable example and a reference guide for Zig's filesystem module. Run the example with:
+
+```sh
+zig run main.zig
+```
+
+## Global functions
+- `std.fs.cwd()` – return the current working directory handle
+- `std.fs.updateFileAbsolute(src, dest, args)` – copy if source is newer
+- `std.fs.copyFileAbsolute(src, dest, args)` – copy a file between absolute paths
+- `std.fs.makeDirAbsolute(path)` / `makeDirAbsoluteZ` / `makeDirAbsoluteW` – create a directory
+- `std.fs.deleteDirAbsolute(path)` / `deleteDirAbsoluteZ` / `deleteDirAbsoluteW` – remove an empty directory
+- `std.fs.renameAbsolute(old, new)` / `renameAbsoluteZ` / `renameAbsoluteW` – rename a file or directory
+- `std.fs.openDirAbsolute(path, flags)` – open a directory
+- `std.fs.openFileAbsolute(path, flags)` – open a file
+- `std.fs.accessAbsolute(path, flags)` – check access rights
+- `std.fs.createFileAbsolute(path, flags)` – create a new file
+- `std.fs.deleteFileAbsolute(path)` / `deleteFileAbsoluteZ` / `deleteFileAbsoluteW` – delete a file
+- `std.fs.deleteTreeAbsolute(path)` – recursively delete a directory tree
+- `std.fs.readLinkAbsolute(path, buffer)` – read a symbolic link target
+- `std.fs.symLinkAbsolute(target, link_path, ...)` – create a symbolic link
+- `std.fs.openSelfExe(flags)` – open the running executable
+- `std.fs.selfExePathAlloc(allocator)` / `selfExePath` – get path to the executable
+- `std.fs.selfExeDirPathAlloc(allocator)` / `selfExeDirPath` – get directory of the executable
+- `std.fs.realpathAlloc(allocator, path)` – canonicalize a path
+
+## `Dir` – directory handle methods
+- `dir.close()` – release resources
+- `dir.openFile(sub_path, flags)` / `openFileZ` / `openFileW` – open a file
+- `dir.createFile(sub_path, flags)` / `createFileZ` / `createFileW` – create a file
+- `dir.makeDir(sub_path)` / `makeDirZ` / `makeDirW` – create a subdirectory
+- `dir.makePath(sub_path)` – create all components of a path
+- `dir.makePathStatus(sub_path)` – report whether the path existed or was created
+- `dir.makeOpenPath(sub_path, open_dir_options)` – create and open a nested directory
+- `dir.realpath(path, buffer)` / `realpathZ` / `realpathW` / `realpathAlloc` – resolve a path
+- `dir.setAsCwd()` – set the process working directory
+- `dir.openDir(sub_path, options)` / `openDirZ` / `openDirW` – open a subdirectory
+- `dir.deleteFile(sub_path)` / `deleteFileZ` / `deleteFileW` – remove a file
+- `dir.deleteDir(sub_path)` / `deleteDirZ` / `deleteDirW` – remove an empty subdirectory
+- `dir.rename(old_sub_path, new_sub_path)` / `renameZ` / `renameW` – rename within the directory
+- `dir.symLink(target, link_path, ...)` / `symLinkZ` / `symLinkW` – create a symbolic link
+- `dir.atomicSymLink(target, tmp_path, final_path)` – create a symbolic link atomically
+- `dir.readLink(sub_path, buffer)` / `readLinkZ` / `readLinkW` – read a symbolic link
+- `dir.readFile(file_path, buffer)` – read a file into a provided buffer
+- `dir.readFileAlloc(file_path, allocator, options?)` – allocate a buffer and read a file
+- `dir.deleteTree(sub_path)` / `deleteTreeMinStackSize` – recursively delete a directory tree
+- `dir.writeFile(options)` – write data to a file, creating or truncating
+- `dir.access(sub_path, flags)` / `accessZ` / `accessW` – check permissions
+- `dir.updateFile(source, dest, args)` – copy if source is newer
+- `dir.copyFile(source, dest, args)` – copy a file
+- `dir.atomicFile(dest_path, options)` – open a temporary file to atomically replace the destination
+- `dir.stat()` – get information about the directory itself
+- `dir.statFile(sub_path)` – get information about a file
+- `dir.chmod(new_mode)` – change permissions
+- `dir.chown(owner, group)` – change ownership
+- `dir.setPermissions(permissions)` – modify POSIX-style permissions
+- `dir.iterate()` / `iterateAssumeFirstIteration()` – iterate over entries
+- `dir.walk(allocator)` – recursively iterate over a tree
+- `Dir.Iterator.next()` / `reset()` – iterator methods
+- `Dir.Walker.next()` / `deinit()` – walker methods
+
+## `File` – file handle methods
+- `file.close()` – close the handle
+- `file.sync()` – flush pending writes to disk
+- `file.isTty()` – check whether the handle is a terminal
+- `file.getOrEnableAnsiEscapeSupport()` / `supportsAnsiEscapeCodes()` – ANSI escape support
+- `file.setEndPos(len)` – truncate or extend the file
+- `file.seekBy(offset)` / `seekFromEnd(offset)` / `seekTo(pos)` – move the file cursor
+- `file.getPos()` / `getEndPos()` – query current position or size
+- `file.mode()` – retrieve mode bits
+- `file.stat()` – obtain `File.Stat` information
+- `file.chmod(new_mode)` / `chown(owner, group)` / `setPermissions(permissions)` – change metadata
+- `file.updateTimes(atime, mtime)` – set access and modification times
+- `file.read(buffer)` / `readAll(buffer)` – read data
+- `file.pread(buffer, offset)` / `preadAll(buffer, offset)` – positional read
+- `file.readv(iovecs)` / `readvAll(iovecs)` – scatter read into multiple buffers
+- `file.preadv(iovecs, offset)` / `preadvAll(iovecs, offset)` – positional scatter read
+- `file.write(bytes)` / `writeAll(bytes)` – write data
+- `file.pwrite(bytes, offset)` / `pwriteAll(bytes, offset)` – positional write
+- `file.writev(iovecs)` / `writevAll(iovecs)` – gather write from multiple buffers
+- `file.pwritev(iovecs, offset)` / `pwritevAll(iovecs, offset)` – positional gather write
+- `file.copyRange(in_offset, out_file, out_offset, len)` / `copyRangeAll` – copy bytes between files
+- `File.reader(file, buffer)` / `readerStreaming` – create a buffered reader
+- `Reader.getSize()` / `seekBy()` / `seekTo()` / `logicalPos()` / `read()` / `readPositional()` / `readStreaming()` / `atEnd()` – reader methods
+- `File.writer(file, buffer)` / `writerStreaming` – create a buffered writer
+- `Writer.seekTo()` / `end()` / `moveToReader()` / `drain()` / `sendFile()` – writer methods
+- `File.lock(lock)` / `tryLock(lock)` / `unlock()` / `downgradeLock()` – advisory file locking
+
+## `path` utilities
+- `path.join(allocator, parts)` – join components into a path
+- `path.joinZ(allocator, parts)` – join components and return a null-terminated string
+- `path.joinWindows(allocator, parts)` – Windows-style join
+- `path.isAbsolute(path)` / `isAbsoluteZ` / `isAbsoluteWindowsW` – test for absolute paths
+- `path.resolve(allocator, base, relative)` – resolve a relative path against a base
+- `path.basename(path)` – final component of a path
+- `path.extension(path)` – file extension
+- `path.dirname(path)` – everything except the final component
+- `path.normalize(allocator, path)` – clean up "." and ".." segments
+- `path.relative(allocator, base, target)` – compute a relative path
+- `path.sep_bytes` / `path.sep_char` – directory separator constants
+
+This document summarizes the functions available in `std.fs` and groups them by purpose for quick reference.

--- a/std/fs/main.zig
+++ b/std/fs/main.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var cwd = std.fs.cwd();
+    const tmp_name = "fs_example.txt";
+
+    // Create and write a file.
+    {
+        var file = try cwd.createFile(tmp_name, .{ .read = true, .truncate = true });
+        defer file.close();
+        try file.writeAll("Przykład modułu std.fs\n");
+    }
+
+    // Read the file back into memory.
+    const contents = try std.fs.readFileAlloc(std.heap.page_allocator, tmp_name);
+    defer std.heap.page_allocator.free(contents);
+    defer cwd.deleteFile(tmp_name) catch {};
+
+    std.debug.print("Plik zawiera: {s}", .{contents});
+}

--- a/std/io/README.md
+++ b/std/io/README.md
@@ -1,0 +1,117 @@
+# std.io – wejście/wyjście
+
+Moduł `std.io` dostarcza prymitywów do pracy ze strumieniami
+wejścia/wyjścia. Obejmuje on uchwyty do standardowych strumieni,
+uogólnione interfejsy `Reader` i `Writer`, mechanizmy buforowania oraz
+narzędzia do pracy z danymi w pamięci. Znajomość tych elementów pozwala
+na budowanie efektywnych i przenośnych programów konsolowych.
+
+## Uruchomienie przykładu
+
+```sh
+zig run main.zig
+```
+
+## Standardowe strumienie
+
+Zig udostępnia trzy podstawowe strumienie:
+
+- `std.io.getStdIn()` – wejście standardowe
+- `std.io.getStdOut()` – wyjście standardowe
+- `std.io.getStdErr()` – strumień błędów
+
+Każdy z nich zwraca strukturę zawierającą metody `reader()` lub
+`writer()` pozwalające pobrać odpowiedni interfejs.
+
+```zig
+const stdin = std.io.getStdIn().reader();
+const stdout = std.io.getStdOut().writer();
+
+try stdout.print("Wpisz tekst i zakończ Enterem: ", .{});
+var buf: [100]u8 = undefined;
+const line = try stdin.readUntilDelimiterOrEof(&buf, '\n');
+try stdout.print("Otrzymano: {s}\n", .{line});
+```
+
+## Czytniki i pisarze
+
+`Reader` i `Writer` to generyczne interfejsy opisujące operacje odczytu
+oraz zapisu. Wiele typów – pliki, gniazda sieciowe, strumienie w
+pamięci – implementuje te interfejsy, dzięki czemu kod może być
+ponownie użyty z różnymi źródłami danych.
+
+Najważniejsze metody:
+
+- `read` – odczyt określonej liczby bajtów do bufora
+- `readAll` – próbuje wypełnić cały bufor (zwraca błąd przy końcu
+  strumienia)
+- `readUntilDelimiterOrEof` – odczyt do napotkania znaku lub końca
+- `write`/`writeAll` – zapis danych
+- `print` – formatowany zapis podobny do `printf`
+
+## Buforowanie
+
+Bezpośrednie operacje na strumieniach mogą wiązać się z częstymi
+wywołaniami systemowymi. Aby je ograniczyć, warto używać
+`bufferedReader` i `bufferedWriter`.
+
+```zig
+var stdin_file = std.io.getStdIn();
+var stdout_file = std.io.getStdOut();
+
+var br = std.io.bufferedReader(stdin_file.reader());
+var bw = std.io.bufferedWriter(stdout_file.writer());
+const reader = br.reader();
+var writer = bw.writer();
+
+try writer.print("Podaj imię: ", .{});
+try bw.flush();
+var name_buf: [32]u8 = undefined;
+const name = try reader.readUntilDelimiterOrEof(&name_buf, '\n');
+try writer.print("Witaj, {s}!\n", .{name});
+try bw.flush();
+```
+
+> **Porada:** pamiętaj o `flush()` – bez tego dane pozostaną w buforze i
+> nie pojawią się na ekranie.
+
+## Strumienie w pamięci
+
+Gdy potrzebny jest strumień działający na tablicy bajtów w pamięci,
+użyj `std.io.fixedBufferStream`.
+
+```zig
+var storage: [64]u8 = undefined;
+var fbs = std.io.fixedBufferStream(&storage);
+const w = fbs.writer();
+try w.print("liczba={d}", .{42});
+const written = fbs.getWritten();
+// written zawiera zapisany ciąg "liczba=42"
+```
+
+Istnieje również `std.io.BufferAllocatorStream`, który dynamicznie
+powiększa bufor przy użyciu przydzielacza.
+
+## Null stream
+
+`std.io.nullWriter` oraz `std.io.nullReader` pozwalają odrzucać dane lub
+zastępować brakujące źródła/cele wejścia i wyjścia.
+
+```zig
+const sink = std.io.nullWriter;
+try sink.print("To się nie pojawi nigdzie\n", .{});
+```
+
+## Dobre praktyki
+
+- Każda operacja I/O może zwrócić błąd – propaguj je przy użyciu `?`
+  lub obsłuż.
+- Reużywaj buforów, aby unikać dynamicznych alokacji.
+- Funkcja `std.io.isatty` pozwala sprawdzić, czy strumień jest terminalem
+  (przydatne do warunkowego formatowania).
+- Strumienie są domyślnie blokujące; w przypadku potrzeby operacji
+  asynchronicznych skorzystaj z `async` oraz `std.io.poll`.
+
+`std.io` stanowi podstawę wielu innych części biblioteki – zrozumienie
+jego mechanizmów ułatwi pracę z plikami, siecią i formatowaniem danych.
+

--- a/std/io/main.zig
+++ b/std/io/main.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+
+pub fn main() !void {
+    // Uzyskaj uchwyty do standardowych strumieni
+    var stdout_file = std.io.getStdOut();
+    var stdin_file = std.io.getStdIn();
+
+    // Opakuj strumienie w bufory, aby zmniejszyć liczbę wywołań systemowych
+    var bw = std.io.bufferedWriter(stdout_file.writer());
+    var br = std.io.bufferedReader(stdin_file.reader());
+    const stdout = bw.writer();
+    const stdin = br.reader();
+
+    try stdout.print("Podaj swoją ulubioną liczbę: ", .{});
+    // Buforowany writer wymaga ręcznego opróżnienia
+    try bw.flush();
+
+    var buf: [100]u8 = undefined;
+    // Czytanie aż do znaku nowej linii lub końca pliku
+    const line = (try stdin.readUntilDelimiterOrEof(&buf, '\n')) orelse {
+        try stdout.print("Brak danych wejściowych.\n", .{});
+        return;
+    };
+
+    // Parsowanie liczby z otrzymanego ciągu znaków
+    const number = try std.fmt.parseInt(i64, line, 10);
+    try stdout.print("Liczba powiększona o 1 to {d}\n", .{number + 1});
+    try bw.flush();
+}


### PR DESCRIPTION
## Summary
- add std/fs example creating, reading, and deleting a file
- add std/fmt example using `bufPrint`
- add std/io example reading from stdin and writing to stdout
- expand std/fs README with comprehensive function reference
- expand std/io README with detailed guide and buffered I/O example
